### PR TITLE
Add option to enable telescope with default look with borders

### DIFF
--- a/lua/base16-colorscheme.lua
+++ b/lua/base16-colorscheme.lua
@@ -82,6 +82,7 @@ M.highlight = setmetatable({}, {
 function M.with_config(config)
     M.config = vim.tbl_extend("force", {
         telescope = true,
+        telescope_borders = false,
         indentblankline = true,
         notify = true,
         ts_rainbow = true,
@@ -424,7 +425,8 @@ function M.setup(colors, config)
     hi.TreesitterContext = { guifg = nil, guibg = M.colors.base01, gui = 'italic', guisp = nil }
 
     if M.config.telescope then
-        if hex_re:match_str(M.colors.base00) and hex_re:match_str(M.colors.base01) and hex_re:match_str(M.colors.base02) then
+        if not M.config.telescope_borders and hex_re:match_str(M.colors.base00) and hex_re:match_str(M.colors.base01) and
+            hex_re:match_str(M.colors.base02) then
             local darkerbg           = darken(M.colors.base00, 0.1)
             local darkercursorline   = darken(M.colors.base01, 0.1)
             local darkerstatusline   = darken(M.colors.base02, 0.1)
@@ -437,6 +439,17 @@ function M.setup(colors, config)
             hi.TelescopePromptTitle  = { guifg = darkercursorline, guibg = M.colors.base08, gui = nil, guisp = nil }
             hi.TelescopeResultsTitle = { guifg = darkerbg, guibg = darkerbg, gui = nil, guisp = nil }
             hi.TelescopeSelection    = { guifg = nil, guibg = darkerstatusline, gui = nil, guisp = nil }
+            hi.TelescopePreviewLine  = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil }
+        else
+            hi.TelescopeBorder       = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil }
+            hi.TelescopePromptBorder = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil }
+            hi.TelescopePromptNormal = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil }
+            hi.TelescopePromptPrefix = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil }
+            hi.TelescopeNormal       = { guifg = nil, guibg = M.colors.base00, gui = nil, guisp = nil }
+            hi.TelescopePreviewTitle = { guifg = M.colors.base01, guibg = M.colors.base0B, gui = nil, guisp = nil }
+            hi.TelescopePromptTitle  = { guifg = M.colors.base01, guibg = M.colors.base08, gui = nil, guisp = nil }
+            hi.TelescopeResultsTitle = { guifg = M.colors.base05, guibg = M.colors.base00, gui = nil, guisp = nil }
+            hi.TelescopeSelection    = { guifg = nil, guibg = M.colors.base01, gui = nil, guisp = nil }
             hi.TelescopePreviewLine  = { guifg = nil, guibg = M.colors.base01, gui = 'none', guisp = nil }
         end
     end


### PR DESCRIPTION
The default configuration of telescope popups currently is to hide the default borders and the Results title, which looks cool, but I'd like to see the option to use the default look as well!

| Default look without borders             |  With borders and Results title |
:-------------------------:|:-------------------------:
![Screenshot 2023-01-31 at 9 24 52](https://user-images.githubusercontent.com/39521244/215709356-4bb8a15c-3dca-4f01-b9c5-7a5fe7f9610e.png) | ![Screenshot 2023-01-31 at 9 24 02](https://user-images.githubusercontent.com/39521244/215709399-df28a44b-18c8-4bf2-a204-b9c49d7d8c90.png)
